### PR TITLE
React native js bridge for setAttachmentTypesEnabled instabug method

### DIFF
--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -212,6 +212,23 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
     }
 
     /**
+     * Sets whether attachments in bug reporting and in-app messaging are enabled or not.
+     * @param {boolean} screenShot A boolean to enable or disable screenshot attachments.
+     * @param {boolean} extraScreenShot A boolean to enable or disable extra screenshot attachments.
+     * @param {boolean} galleryImage A boolean to enable or disable gallery image attachments.
+     * @param {boolean} voiceNote A boolean to enable or disable voice note attachments.
+     * @param {boolean} screenRecording A boolean to enable or disable screen recording attachments.
+     */
+    @ReactMethod
+    public void setAttachmentTypesEnabled(boolean screenshot, boolean extraScreenshot, boolean galleryImage, boolean voiceNote, boolean screenRecording) {
+        try {
+            mInstabug.setAttachmentTypesEnabled(screenshot, extraScreenshot, galleryImage, voiceNote, screenRecording);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
      * Appends a log message to Instabug internal log
      * <p>
      * These logs are then sent along the next uploaded report. All log messages are timestamped <br/>


### PR DESCRIPTION
Missing to be bridge for android since the iOS lib is already doing it and the react-native js module is exposing it.

https://github.com/Instabug/instabug-reactnative/blob/master/index.js#L397