### PR TITLE
Rename log to IBGLog in Android module

### DIFF
--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -239,7 +239,7 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
      * @param message log message
      */
     @ReactMethod
-    public void log(String message) {
+    public void IBGLog(String message) {
         try {
             mInstabug.log(message);
         } catch (Exception e) {


### PR DESCRIPTION
This PR fixes
> TypeError: undefined is not a function (evaluating 'Instabug.IBGLog(log)')

at `Instabug.IBGLog("test")` invocation.