### PR TITLE
Remove flow annotation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,3 @@
-/**
- * Sample React Native App
- * https://github.com/facebook/react-native
- * @flow
- */
-
 import {NativeModules, NativeAppEventEmitter, Platform} from 'react-native';
 
 let {Instabug} = NativeModules;


### PR DESCRIPTION
Having a `// @flow` comment in the file without annotations will throw flow errors