### PR TITLE
Fix/move instabug instantiation to android application class

### DIFF
--- a/InstabugSample/android/app/build.gradle
+++ b/InstabugSample/android/app/build.gradle
@@ -129,8 +129,8 @@ android {
 }
 
 dependencies {
-    compile project(':react-native-dialogs')
     compile project(':instabug-reactnative')
+    compile project(':react-native-dialogs')
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:+"  // From node_modules

--- a/InstabugSample/android/app/build.gradle
+++ b/InstabugSample/android/app/build.gradle
@@ -130,7 +130,6 @@ android {
 
 dependencies {
     compile project(':instabug-reactnative')
-    compile project(':react-native-dialogs')
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:+"  // From node_modules

--- a/InstabugSample/android/app/build.gradle
+++ b/InstabugSample/android/app/build.gradle
@@ -129,8 +129,8 @@ android {
 }
 
 dependencies {
-    compile project(':instabug-reactnative')
     compile project(':react-native-dialogs')
+    compile project(':instabug-reactnative')
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:+"  // From node_modules

--- a/InstabugSample/android/app/src/main/java/com/instabugsample/MainApplication.java
+++ b/InstabugSample/android/app/src/main/java/com/instabugsample/MainApplication.java
@@ -28,9 +28,7 @@ public class MainApplication extends Application implements ReactApplication {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
             new ReactNativeDialogsPackage(),
-            new RNInstabugReactnativePackage("YOUR_ANDROID_APPLICATION_TOKEN",
-            MainApplication.this,"button")
-
+            new RNInstabugReactnativePackage("YOUR_ANDROID_APPLICATION_TOKEN",MainApplication.this)
       );
     }
   };

--- a/InstabugSample/android/app/src/main/java/com/instabugsample/MainApplication.java
+++ b/InstabugSample/android/app/src/main/java/com/instabugsample/MainApplication.java
@@ -5,7 +5,6 @@ import android.util.Log;
 
 import com.facebook.react.ReactApplication;
 import com.instabug.reactlibrary.RNInstabugReactnativePackage;
-import com.aakashns.reactnativedialogs.ReactNativeDialogsPackage;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
@@ -27,8 +26,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
-            new RNInstabugReactnativePackage("YOUR_ANDROID_APPLICATION_TOKEN",MainApplication.this,"shake","#1D82DC"),
-            new ReactNativeDialogsPackage()
+            new RNInstabugReactnativePackage("YOUR_ANDROID_APPLICATION_TOKEN",MainApplication.this,"shake","#1D82DC")
       );
     }
   };

--- a/InstabugSample/android/app/src/main/java/com/instabugsample/MainApplication.java
+++ b/InstabugSample/android/app/src/main/java/com/instabugsample/MainApplication.java
@@ -4,8 +4,8 @@ import android.app.Application;
 import android.util.Log;
 
 import com.facebook.react.ReactApplication;
-import com.aakashns.reactnativedialogs.ReactNativeDialogsPackage;
 import com.instabug.reactlibrary.RNInstabugReactnativePackage;
+import com.aakashns.reactnativedialogs.ReactNativeDialogsPackage;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
@@ -27,8 +27,8 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
-            new ReactNativeDialogsPackage(),
-            new RNInstabugReactnativePackage("YOUR_ANDROID_APPLICATION_TOKEN",MainApplication.this)
+            new RNInstabugReactnativePackage("YOUR_ANDROID_APPLICATION_TOKEN",MainApplication.this,"shake","#1D82DC"),
+            new ReactNativeDialogsPackage()
       );
     }
   };

--- a/InstabugSample/android/settings.gradle
+++ b/InstabugSample/android/settings.gradle
@@ -1,7 +1,5 @@
 rootProject.name = 'InstabugSample'
 include ':instabug-reactnative'
 project(':instabug-reactnative').projectDir = new File(rootProject.projectDir, '../node_modules/instabug-reactnative/android')
-include ':react-native-dialogs'
-project(':react-native-dialogs').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-dialogs/android')
 
 include ':app'

--- a/InstabugSample/android/settings.gradle
+++ b/InstabugSample/android/settings.gradle
@@ -1,7 +1,7 @@
 rootProject.name = 'InstabugSample'
-include ':react-native-dialogs'
-project(':react-native-dialogs').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-dialogs/android')
 include ':instabug-reactnative'
 project(':instabug-reactnative').projectDir = new File(rootProject.projectDir, '../node_modules/instabug-reactnative/android')
+include ':react-native-dialogs'
+project(':react-native-dialogs').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-dialogs/android')
 
 include ':app'

--- a/InstabugSample/index.android.js
+++ b/InstabugSample/index.android.js
@@ -14,12 +14,10 @@ import {
     processColor,
     Aerlt,
     Image,
-    ListView,
     TouchableHighlight,
     RecyclerViewBackedScrollView
 } from "react-native";
 import Instabug from "instabug-reactnative";
-let DialogAndroid = require('react-native-dialogs');
 
 export default class InstabugSample extends Component {
 
@@ -30,294 +28,52 @@ export default class InstabugSample extends Component {
         Instabug.setPrimaryColor(processColor('#aaff00'));
         Instabug.setEmailFieldRequired(false);
 
-        const ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
-        this.state = {
-            dataSource: ds.cloneWithRows(this._genRows({})),
-        };
     }
 
-    _renderRow(rowData, sectionID, rowID, highlightRow) {
-        const that = this;
-        return (
-            <TouchableHighlight onPress={() => {
-                that._pressRow(rowID);
-                highlightRow(sectionID, rowID);
-            }}>
-                <View>
-                    <View style={styles.row}>
-                        <Text style={styles.text}>
-                            {rowData}
-                        </Text>
-                    </View>
-                </View>
-            </TouchableHighlight>
-        );
-    }
-
-    _genRows() {
-        var dataBlob = [
-            "Invoke",
-            "Invoke with invocation mode",
-            "Select invocation event",
-            "Show intro message",
-            "Unread messages count",
-            "Set locale",
-            "Set color theme",
-            "Set primary color"
-        ];
-        return dataBlob;
-    }
-
-    _pressRow(rowID) {
-        if (rowID == 0) {
-            Instabug.invoke();
-        } else if (rowID == 1) {
-            this._showInvocationModeActionSheet();
-        } else if (rowID == 2) {
-            this._showInvocationEventActionSheet();
-        } else if (rowID == 3) {
-            Instabug.showIntroMessage();
-        } else if (rowID == 4) {
-
-            Instabug.getUnreadMessagesCount((count) => {
-                Alert.alert("UnReadMessages", "Messages: " + count);
-            });
-
-        } else if (rowID == 5) {
-            this._showLocaleActionSheet();
-        } else if (rowID == 6) {
-            this._showColorThemeActionSheet();
-        } else if (rowID == 7) {
-            this._showPrimaryColorActionSheet();
-        }
-    }
-
-    _showInvocationModeActionSheet() {
-        let options = {
-            "items": [
-                "New bug",
-                "New Feedback",
-                "New Chat",
-                "None"
-            ],
-            "title": "Instabug modes",
-            itemsCallback: (id, text) => {
-                if (id == 0) {
-                    Instabug.invokeWithInvocationMode(Instabug.invocationMode.newBug);
-                } else if (id == 1) {
-                    Instabug.invokeWithInvocationMode(Instabug.invocationMode.newFeedback);
-                } else if (id == 2) {
-                    Instabug.invokeWithInvocationMode(Instabug.invocationMode.newChat);
-                } else if (id == 3) {
-                    Instabug.invokeWithInvocationMode(Instabug.invocationMode.NA);
-                }
-            }
-        };
-
-        showDialog = function () {
-            let dialog = new DialogAndroid();
-            dialog.set(options);
-            dialog.show();
-        };
-
-        showDialog();
-    }
-
-    _showColorThemeActionSheet() {
-        let options = {
-            "items": [
-                "Light",
-                "Dark"
-            ],
-            "title": "Instabug Themes",
-            itemsCallback: (id, text) => {
-                if (id == 0) {
-                    Instabug.setColorTheme(Instabug.colorTheme.light);
-                } else if (id == 1) {
-                    Instabug.setColorTheme(Instabug.colorTheme.dark);
-                }
-            }
-        };
-
-        showDialog = function () {
-            let dialog = new DialogAndroid();
-            dialog.set(options);
-            dialog.show();
-        };
-
-        showDialog();
-    }
-
-    _showPrimaryColorActionSheet() {
-        let options = {
-            "items": [
-                "Red",
-                "Green",
-                "Blue"
-            ],
-            "title": "Instabug Primary Color",
-            itemsCallback: (id, text) => {
-                if (id == 0) {
-                    Instabug.setPrimaryColor(processColor('#ff0000'));
-                } else if (id == 1) {
-                    Instabug.setPrimaryColor(processColor('#00ff00'));
-                } else if (id == 2) {
-                    Instabug.setPrimaryColor(processColor('#0000ff'));
-                }
-            }
-        };
-
-        showDialog = function () {
-            let dialog = new DialogAndroid();
-            dialog.set(options);
-            dialog.show();
-        };
-
-        showDialog();
-    }
-
-    _showLocaleActionSheet() {
-
-        let options = {
-            "items": [
-                "Arabic",
-                "Chinese Simplified",
-                "Chinese Traditional",
-                "Czech",
-                "Danish",
-                "English",
-                "French",
-                "German",
-                "Italian",
-                "Japanese",
-                "Polish",
-                "Portuguese Brazil",
-                "Russian",
-                "Spanish",
-                "Swedish",
-                "Turkish"
-            ],
-            "title": "Instabug Primary Color",
-            itemsCallback: (id, text) => {
-                if (id == 0) {
-                    Instabug.setLocale(Instabug.locale.arabic);
-                } else if (id == 1) {
-                    Instabug.setLocale(Instabug.locale.chineseSimplified);
-                } else if (id == 2) {
-                    Instabug.setLocale(Instabug.locale.chineseTraditional);
-                } else if (id == 3) {
-                    Instabug.setLocale(Instabug.locale.czech);
-                } else if (id == 4) {
-                    Instabug.setLocale(Instabug.locale.danish);
-                } else if (id == 5) {
-                    Instabug.setLocale(Instabug.locale.english);
-                } else if (id == 6) {
-                    Instabug.setLocale(Instabug.locale.french);
-                } else if (id == 7) {
-                    Instabug.setLocale(Instabug.locale.german);
-                } else if (id == 8) {
-                    Instabug.setLocale(Instabug.locale.italian);
-                } else if (id == 9) {
-                    Instabug.setLocale(Instabug.locale.japanese);
-                } else if (id == 10) {
-                    Instabug.setLocale(Instabug.locale.polish);
-                } else if (id == 11) {
-                    Instabug.setLocale(Instabug.locale.portugueseBrazil);
-                } else if (id == 12) {
-                    Instabug.setLocale(Instabug.locale.russian);
-                } else if (id == 13) {
-                    Instabug.setLocale(Instabug.locale.spanish);
-                } else if (id == 14) {
-                    Instabug.setLocale(Instabug.locale.swedish);
-                } else if (id == 15) {
-                    Instabug.setLocale(Instabug.locale.turkish);
-                }
-            }
-        };
-
-        showDialog = function () {
-            let dialog = new DialogAndroid();
-            dialog.set(options);
-            dialog.show();
-        };
-
-        showDialog();
-    }
-
-    _showInvocationEventActionSheet() {
-
-
-        let options = {
-            "items": [
-                "Shake",
-                "Screenshot",
-                "Two fingers swipe",
-                "Floating button"
-            ],
-            "title": "Instabug Themes",
-            itemsCallback: (id, text) => {
-                if (id == 0) {
-                    Instabug.setInvocationEvent(Instabug.invocationEvent.shake);
-                } else if (id == 1) {
-                    Instabug.setInvocationEvent(Instabug.invocationEvent.screenshot);
-                } else if (id == 2) {
-                    Instabug.setInvocationEvent(Instabug.invocationEvent.twoFingersSwipe);
-                } else if (id) {
-                    Instabug.setInvocationEvent(Instabug.invocationEvent.floatingButton);
-                }
-            }
-        };
-
-        showDialog = function () {
-            let dialog = new DialogAndroid();
-            dialog.set(options);
-            dialog.show();
-        };
-
-        showDialog();
-    }
-
-    _renderSeparator(sectionID, rowID, adjacentRowHighlighted) {
-        return (
-            <View
-                key={`${sectionID}-${rowID}`}
-                style={{
-                    height: adjacentRowHighlighted ? 4 : 1,
-                    backgroundColor: adjacentRowHighlighted ? '#3B5998' : '#CCCCCC',
-                }}
-            />
-        );
-    }
 
     render() {
-        console.log(JSON.stringify(this.state));
         return (
-            <ListView
-                dataSource={this.state.dataSource}
-                renderRow={this._renderRow.bind(this)}
-                renderScrollComponent={props => <RecyclerViewBackedScrollView {...props} />}
-                style={styles.listView}
-            />
+            <View style={styles.container}>
+                <Text style={styles.welcome}>
+                    Welcome to React Native!
+                </Text>
+                <Text style={styles.instructions}>
+                    To get started, edit index.android.js
+                </Text>
+                <Text style={styles.instructions}>
+                    Double tap R on your keyboard to reload,{'\n'}
+                    Shake or press menu button for dev menu
+                </Text>
+                <Button
+                    onPress={() => {
+                                console.log("invoke Button has been clicked");
+                                Instabug.invoke()}}
+                    title="Invoke Instabug"
+                    color="#841584"
+                    disabled={false}
+                    accessibilityLabel="Learn more about this purple button"
+                />
+            </View>
         );
     }
 }
 
 const styles = StyleSheet.create({
-    row: {
-        flexDirection: 'row',
-        justifyContent: 'center',
-        padding: 10,
-        backgroundColor: '#F6F6F6',
-    },
-    thumb: {
-        width: 64,
-        height: 64,
-    },
-    text: {
+    container: {
         flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: '#F5FCFF',
     },
-    listView: {
-        paddingTop: 20
+    welcome: {
+        fontSize: 20,
+        textAlign: 'center',
+        margin: 10,
+    },
+    instructions: {
+        textAlign: 'center',
+        color: '#333333',
+        marginBottom: 5,
     },
 });
 

--- a/InstabugSample/index.android.js
+++ b/InstabugSample/index.android.js
@@ -25,11 +25,11 @@ export default class InstabugSample extends Component {
 
     constructor(props) {
         super(props);
-        Instabug.startWithToken('0f0dc916bd9175e3b5d2fdf0cfa49a69',
-            Instabug.invocationEvent.floatingButton);
-        Instabug.setPreInvocationHandler(() => {
-            Alert.alert("PreInvocationEvent", "Done :) ");
-        });
+
+        Instabug.setColorTheme(Instabug.colorTheme.light);
+        Instabug.setPrimaryColor(processColor('#aaff00'));
+        Instabug.setEmailFieldRequired(false);
+
         const ds = new ListView.DataSource({rowHasChanged: (r1, r2) => r1 !== r2});
         this.state = {
             dataSource: ds.cloneWithRows(this._genRows({})),

--- a/InstabugSample/ios/InstabugSample.xcodeproj/project.pbxproj
+++ b/InstabugSample/ios/InstabugSample.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -36,8 +35,8 @@
 		2DCD954D1E0B4F2C00145EB5 /* InstabugSampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* InstabugSampleTests.m */; };
 		5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
-		E55D333604B942E09167708C /* libRNInstabug.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5632439F28464ECB86D23318 /* libRNInstabug.a */; };
 		FB6237B8BC81FC0C990E8BE6 /* libPods-InstabugSample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E9562565B465A2839B076D83 /* libPods-InstabugSample.a */; };
+		DCC755EDCD9B460F84658AAD /* libRNInstabug.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FED4204D49074081B94F4448 /* libRNInstabug.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -103,13 +102,6 @@
 			proxyType = 2;
 			remoteGlobalIDString = 83CBBA2E1A601D0E00E9B192;
 			remoteInfo = React;
-		};
-		24C9AC781EFA773C00D07EFB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 68353C997C7F4ED0910B4CFA /* RNInstabug.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 24DF11ED1DA3A2B90056F77C;
-			remoteInfo = RNInstabug;
 		};
 		2D02E4911E0B4A5D006451C7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -262,13 +254,13 @@
 		21DED4D3594E0D93E837631F /* Pods-InstabugSample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InstabugSample.release.xcconfig"; path = "Pods/Target Support Files/Pods-InstabugSample/Pods-InstabugSample.release.xcconfig"; sourceTree = "<group>"; };
 		2D02E47B1E0B4A5D006451C7 /* InstabugSample-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "InstabugSample-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D02E4901E0B4A5D006451C7 /* InstabugSample-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "InstabugSample-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		5632439F28464ECB86D23318 /* libRNInstabug.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNInstabug.a; sourceTree = "<group>"; };
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
-		68353C997C7F4ED0910B4CFA /* RNInstabug.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNInstabug.xcodeproj; path = "../node_modules/instabug-reactnative/ios/RNInstabug.xcodeproj"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
 		8601D784DB38337F6E545397 /* Pods-InstabugSample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InstabugSample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-InstabugSample/Pods-InstabugSample.debug.xcconfig"; sourceTree = "<group>"; };
 		E9562565B465A2839B076D83 /* libPods-InstabugSample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-InstabugSample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A0FE88E32F084FD8A95E38DF /* RNInstabug.xcodeproj */ = {isa = PBXFileReference; name = "RNInstabug.xcodeproj"; path = "../node_modules/instabug-reactnative/ios/RNInstabug.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		FED4204D49074081B94F4448 /* libRNInstabug.a */ = {isa = PBXFileReference; name = "libRNInstabug.a"; path = "libRNInstabug.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -296,7 +288,7 @@
 				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
 				FB6237B8BC81FC0C990E8BE6 /* libPods-InstabugSample.a in Frameworks */,
-				E55D333604B942E09167708C /* libRNInstabug.a in Frameworks */,
+				DCC755EDCD9B460F84658AAD /* libRNInstabug.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -431,14 +423,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		24C9AC5C1EFA773C00D07EFB /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				24C9AC791EFA773C00D07EFB /* libRNInstabug.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		24ED9F161EFA6BE300D771DA /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
@@ -496,7 +480,7 @@
 				832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */,
 				00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */,
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
-				68353C997C7F4ED0910B4CFA /* RNInstabug.xcodeproj */,
+				A0FE88E32F084FD8A95E38DF /* RNInstabug.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -697,10 +681,6 @@
 					ProductGroup = 146834001AC3E56700842450 /* Products */;
 					ProjectRef = 146833FF1AC3E56700842450 /* React.xcodeproj */;
 				},
-				{
-					ProductGroup = 24C9AC5C1EFA773C00D07EFB /* Products */;
-					ProjectRef = 68353C997C7F4ED0910B4CFA /* RNInstabug.xcodeproj */;
-				},
 			);
 			projectRoot = "";
 			targets = (
@@ -767,13 +747,6 @@
 			fileType = archive.ar;
 			path = libReact.a;
 			remoteRef = 146834031AC3E56700842450 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		24C9AC791EFA773C00D07EFB /* libRNInstabug.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libRNInstabug.a;
-			remoteRef = 24C9AC781EFA773C00D07EFB /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		3DAD3E841DF850E9000B6D8A /* libRCTImage-tvOS.a */ = {

--- a/InstabugSample/ios/InstabugSample.xcodeproj/project.pbxproj
+++ b/InstabugSample/ios/InstabugSample.xcodeproj/project.pbxproj
@@ -36,7 +36,7 @@
 		5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		FB6237B8BC81FC0C990E8BE6 /* libPods-InstabugSample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E9562565B465A2839B076D83 /* libPods-InstabugSample.a */; };
-		DCC755EDCD9B460F84658AAD /* libRNInstabug.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FED4204D49074081B94F4448 /* libRNInstabug.a */; };
+		62F9158A7B074929B2D8A561 /* libRNInstabug.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6C533A1EEE6342FA8421CF36 /* libRNInstabug.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -259,8 +259,8 @@
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
 		8601D784DB38337F6E545397 /* Pods-InstabugSample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-InstabugSample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-InstabugSample/Pods-InstabugSample.debug.xcconfig"; sourceTree = "<group>"; };
 		E9562565B465A2839B076D83 /* libPods-InstabugSample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-InstabugSample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		A0FE88E32F084FD8A95E38DF /* RNInstabug.xcodeproj */ = {isa = PBXFileReference; name = "RNInstabug.xcodeproj"; path = "../node_modules/instabug-reactnative/ios/RNInstabug.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		FED4204D49074081B94F4448 /* libRNInstabug.a */ = {isa = PBXFileReference; name = "libRNInstabug.a"; path = "libRNInstabug.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		1B17852ABF654B8D8B056F8E /* RNInstabug.xcodeproj */ = {isa = PBXFileReference; name = "RNInstabug.xcodeproj"; path = "../node_modules/instabug-reactnative/ios/RNInstabug.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		6C533A1EEE6342FA8421CF36 /* libRNInstabug.a */ = {isa = PBXFileReference; name = "libRNInstabug.a"; path = "libRNInstabug.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -288,7 +288,7 @@
 				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
 				FB6237B8BC81FC0C990E8BE6 /* libPods-InstabugSample.a in Frameworks */,
-				DCC755EDCD9B460F84658AAD /* libRNInstabug.a in Frameworks */,
+				62F9158A7B074929B2D8A561 /* libRNInstabug.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -480,7 +480,7 @@
 				832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */,
 				00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */,
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
-				A0FE88E32F084FD8A95E38DF /* RNInstabug.xcodeproj */,
+				1B17852ABF654B8D8B056F8E /* RNInstabug.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -1064,6 +1064,10 @@
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/InstabugSample.app/InstabugSample";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/instabug-reactnative/ios/RNInstabug/**",
+				);
 			};
 			name = Debug;
 		};
@@ -1085,6 +1089,10 @@
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/InstabugSample.app/InstabugSample";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/instabug-reactnative/ios/RNInstabug/**",
+				);
 			};
 			name = Release;
 		};
@@ -1106,6 +1114,10 @@
 				);
 				PRODUCT_NAME = InstabugSample;
 				VERSIONING_SYSTEM = "apple-generic";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/instabug-reactnative/ios/RNInstabug/**",
+				);
 			};
 			name = Debug;
 		};
@@ -1126,6 +1138,10 @@
 				);
 				PRODUCT_NAME = InstabugSample;
 				VERSIONING_SYSTEM = "apple-generic";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/instabug-reactnative/ios/RNInstabug/**",
+				);
 			};
 			name = Release;
 		};
@@ -1156,6 +1172,10 @@
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/instabug-reactnative/ios/RNInstabug/**",
+				);
 			};
 			name = Debug;
 		};
@@ -1186,6 +1206,10 @@
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/instabug-reactnative/ios/RNInstabug/**",
+				);
 			};
 			name = Release;
 		};

--- a/InstabugSample/package.json
+++ b/InstabugSample/package.json
@@ -9,8 +9,7 @@
   "dependencies": {
     "instabug-reactnative": "file:..",
     "react": "15.4.2",
-    "react-native": "^0.41.2",
-    "react-native-dialogs": "0.0.19"
+    "react-native": "^0.41.2"
   },
   "devDependencies": {
     "babel-jest": "18.0.0",

--- a/InstabugSample/package.json
+++ b/InstabugSample/package.json
@@ -7,7 +7,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "instabug-reactnative": "file:../",
+    "instabug-reactnative": "file:..",
     "react": "15.4.2",
     "react-native": "^0.41.2",
     "react-native-dialogs": "0.0.19"

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -122,7 +122,11 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
         super(reactContext);
         this.androidApplication = androidApplication;
         this.mInstabug = mInstabug;
-        Instabug.invoke();
+        try {
+            Instabug.invoke();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Override

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -118,9 +118,10 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
      * @param mInstabug    the m instabug
      */
     public RNInstabugReactnativeModule(ReactApplicationContext reactContext, Application
-            androidApplication) {
+            androidApplication, Instabug mInstabug) {
         super(reactContext);
         this.androidApplication = androidApplication;
+        this.mInstabug = mInstabug;
     }
 
     @Override

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -124,6 +124,7 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
         this.mInstabug = mInstabug;
         try {
             Instabug.invoke();
+            Instabug.dismiss();
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativeModule.java
@@ -122,6 +122,7 @@ public class RNInstabugReactnativeModule extends ReactContextBaseJavaModule {
         super(reactContext);
         this.androidApplication = androidApplication;
         this.mInstabug = mInstabug;
+        Instabug.invoke();
     }
 
     @Override

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativePackage.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativePackage.java
@@ -10,6 +10,7 @@ import com.facebook.react.uimanager.ViewManager;
 import com.instabug.library.Instabug;
 import com.instabug.library.InstabugColorTheme;
 import com.instabug.library.invocation.InstabugInvocationEvent;
+import android.graphics.Color;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -24,11 +25,37 @@ public class RNInstabugReactnativePackage implements ReactPackage {
     private InstabugInvocationEvent invocationEvent = InstabugInvocationEvent.FLOATING_BUTTON;
     private InstabugColorTheme instabugColorTheme = InstabugColorTheme.InstabugColorThemeLight;
 
-    public RNInstabugReactnativePackage(String androidApplicationToken, Application androidApplication) {
+    public RNInstabugReactnativePackage(String androidApplicationToken, Application androidApplication,
+                                        String invocationEventValue, String primaryColor) {
         this.androidApplication = androidApplication;
         this.mAndroidApplicationToken = androidApplicationToken;
+
+        //setting invocation event
+                if (invocationEventValue.equals("button")) {
+                    this.invocationEvent = InstabugInvocationEvent.FLOATING_BUTTON;
+                } else if (invocationEventValue.equals("swipe")) {
+                    this.invocationEvent = InstabugInvocationEvent.TWO_FINGER_SWIPE_LEFT;
+
+                } else if (invocationEventValue.equals("shake")) {
+                    this.invocationEvent = InstabugInvocationEvent.SHAKE;
+
+                } else if (invocationEventValue.equals("screenshot")) {
+                    this.invocationEvent = InstabugInvocationEvent.SCREENSHOT_GESTURE;
+
+                } else if (invocationEventValue.equals("none")) {
+                    this.invocationEvent = InstabugInvocationEvent.NONE;
+
+                } else {
+                    this.invocationEvent = InstabugInvocationEvent.SHAKE;
+                }
+
+
         mInstabug = new Instabug.Builder(this.androidApplication, this.mAndroidApplicationToken)
+                .setInvocationEvent(this.invocationEvent)
                 .build();
+
+        Instabug.setPrimaryColor(Color.parseColor(primaryColor));
+
     }
 
     @Deprecated

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativePackage.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativePackage.java
@@ -24,31 +24,29 @@ public class RNInstabugReactnativePackage implements ReactPackage {
     private InstabugInvocationEvent invocationEvent = InstabugInvocationEvent.FLOATING_BUTTON;
     private InstabugColorTheme instabugColorTheme = InstabugColorTheme.InstabugColorThemeLight;
 
-    public RNInstabugReactnativePackage(Application androidApplication) {
+    public RNInstabugReactnativePackage(String androidApplicationToken, Application androidApplication) {
         this.androidApplication = androidApplication;
+        this.mAndroidApplicationToken = androidApplicationToken;
+        mInstabug = new Instabug.Builder(this.androidApplication, this.mAndroidApplicationToken)
+                .build();
     }
 
     @Deprecated
-    public RNInstabugReactnativePackage(String androidApplicationToken, Application application) {
-        this(androidApplicationToken, application, "button");
-    }
-
-    @Deprecated
-    public RNInstabugReactnativePackage(String androidApplicationToken, Application application,
+    public RNInstabugReactnativePackage(String androidApplicationToken, Application androidApplication,
                                         String invocationEventValue) {
-        this(androidApplicationToken, application, invocationEventValue, "light");
+        this(androidApplicationToken, androidApplication);
     }
 
     @Deprecated
-    public RNInstabugReactnativePackage(String androidApplicationToken, Application application,
+    public RNInstabugReactnativePackage(String androidApplicationToken, Application androidApplication,
                                         String invocationEventValue, String instabugColorThemeValue) {
-        this.androidApplication = application;
+        this(androidApplicationToken, androidApplication);
     }
 
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
-        modules.add(new RNInstabugReactnativeModule(reactContext, this.androidApplication));
+        modules.add(new RNInstabugReactnativeModule(reactContext, this.androidApplication, this.mInstabug));
         return modules;
     }
 

--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativePackage.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativePackage.java
@@ -58,18 +58,6 @@ public class RNInstabugReactnativePackage implements ReactPackage {
 
     }
 
-    @Deprecated
-    public RNInstabugReactnativePackage(String androidApplicationToken, Application androidApplication,
-                                        String invocationEventValue) {
-        this(androidApplicationToken, androidApplication);
-    }
-
-    @Deprecated
-    public RNInstabugReactnativePackage(String androidApplicationToken, Application androidApplication,
-                                        String invocationEventValue, String instabugColorThemeValue) {
-        this(androidApplicationToken, androidApplication);
-    }
-
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();

--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ module.exports = {
      * the SDK's UI.
      */
     startWithToken: function (token, invocationEvent) {
-        Instabug.startWithToken(token, invocationEvent);
+        if (Platform.OS === 'ios')
+            Instabug.startWithToken(token, invocationEvent);
     },
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "instabug-reactnative",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "React Native plugin for integrating the Instabug SDK",
   "main": "index.js",
   "repository": {
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/Instabug/instabug-reactnative#readme",
   "rnpm": {
     "android": {
-      "packageInstance": "new RNInstabugReactnativePackage(MainApplication.this)"
+      "packageInstance": "new RNInstabugReactnativePackage(\"YOUR_ANDROID_APPLICATION_TOKEN\",MainApplication.this)"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/Instabug/instabug-reactnative#readme",
   "rnpm": {
     "android": {
-      "packageInstance": "new RNInstabugReactnativePackage(\"YOUR_ANDROID_APPLICATION_TOKEN\",MainApplication.this)"
+      "packageInstance": "new RNInstabugReactnativePackage(\"YOUR_ANDROID_APPLICATION_TOKEN\",MainApplication.this,\"shake\",\"#1D82DC\")"
     }
   }
 }


### PR DESCRIPTION
Move instantiating Instabug to the Android Entry point itself instead of instantiating Instabug in the bridging file to fix InstabugSDK delay issue.
So, We changed the integration steps which is going to be included in our docs and the readme as well.