### PR TITLE
0.47 backward compatibile Android support

### DIFF
--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativePackage.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativePackage.java
@@ -133,7 +133,6 @@ public class RNInstabugReactnativePackage implements ReactPackage {
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
React Native 0.47 has removed the `createJSModules` method. Had to remove the `@Override` to make the lib compatible with that version of RN.

https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8