### PR TITLE
Removed the postinstall script from package.json

### DIFF
--- a/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativePackage.java
+++ b/android/src/main/java/com/instabug/reactlibrary/RNInstabugReactnativePackage.java
@@ -133,7 +133,6 @@ public class RNInstabugReactnativePackage implements ReactPackage {
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "instabug-reactnative",
   "version": "1.2.4",
   "description": "React Native plugin for integrating the Instabug SDK",
-  "scripts": {
-    "postinstall": "cd ../../ios && pod install"
-  },
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I believe it's not a good idea to mix pods with npm.
That `postinstall` script can only cause trouble (i.e our CI build now fails because of this).
It's very easy to `pod install` how come did you decide to force it?