### PR TITLE
Removed the postinstall script from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "instabug-reactnative",
   "version": "1.2.4",
   "description": "React Native plugin for integrating the Instabug SDK",
-  "scripts": {
-    "postinstall": "cd ../../ios && pod install"
-  },
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I believe it's not a good idea to mix pods with npm.
That `postinstall` script can only cause trouble (i.e our CI build now fails because of this).
It's very easy to `pod install` how come did you decide to force it?

Apart from the CI failing to build, another problem I see with that is you force us to `pod install` on `postinstall` and so we don't get to decide when to `pod install` ourselves.

That means that if we decide to `pod install` later we'll have ran `pod install` more than once = huge build times for no reason.

