### PR TITLE
Rename iOS exported method 'logout' to 'logOut' to match Android implementation

### DIFF
--- a/ios/RNInstabug/InstabugReactBridge.m
+++ b/ios/RNInstabug/InstabugReactBridge.m
@@ -229,7 +229,7 @@ RCT_EXPORT_METHOD(identifyUserWithEmail:(NSString *)email name:(NSString *)name)
     [Instabug identifyUserWithEmail:email name:name];
 }
 
-RCT_EXPORT_METHOD(logout) {
+RCT_EXPORT_METHOD(logOut) {
     [Instabug logOut];
 }
 


### PR DESCRIPTION
The "logOut" method should be exposed with the same name in both iOS and Android. Currently it is necessary to write platform specific JS code to handle both cases. This PR renames the iOS exposed 'logout' method to 'logOut' to match Android.

This would be a breaking change for future iOS versions. The method could be overloaded to provide backward compatibility. I'd be happy to update this PR in that case.


