### PR TITLE
Add requiresMainQueueSetup method

### DIFF
--- a/ios/RNInstabug/InstabugReactBridge.m
+++ b/ios/RNInstabug/InstabugReactBridge.m
@@ -439,6 +439,11 @@ RCT_EXPORT_METHOD(isRunningLive:(RCTResponseSenderBlock)callback) {
               };
 };
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 + (BOOL)iOSVersionIsLessThan:(NSString *)iOSVersion {
     return [iOSVersion compare:[UIDevice currentDevice].systemVersion options:NSNumericSearch] == NSOrderedDescending;
 };


### PR DESCRIPTION
Since RN 0.49, `requiresMainQueueSetup` needs to be defined if the module overrides `constantsToExport`.